### PR TITLE
Expiry, it happens anyway, make more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@
 The [Commons Clause](https://commonsclause.com) is a License Condition drafted by Heather Meeker and contributed by [FOSSA](https://fossa.io).
 
 ```plaintext
-“Commons Clause” License Condition v1.0
+“Commons Clause” License Condition v2.0
 
 The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
 
-Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you,  right to Sell the Software.
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you, right to Sell the Software. When the clause expires, it can be removed, leaving the underlying license, removing proprietary status (in case the underlying licence isn't). Distributors can also change to a later expiry year.
 
 For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software.  Any license notice or attribution required by the License must also include this Commons Cause License Condition notice.
 
 Software: [name software]
 License: [i.e. Apache 2.0]
 Licensor: [ABC company]
+Clause expires: [year]
 ```
 
 ## About


### PR DESCRIPTION
Note, a work, including programs, loses copyright (here proprietary) status, in 70+ years. That seems like way to long.

Some purists, e.g. Richard Stallman, would never add this clause ever, NOR USE any software that has it, ever. If you put a year like 3 or 5 years into the future, they would not use it for that time, but then can remove, and would be happy. The FSF objects to the clause, would still do, but at least it and their followers could remove:

https://www.i-programmer.info/news/136-open-source/12289-fsf-commons-clause-no.html

My wording probably needs amendment, I'm not a lawyer, I'm more interested in the discussion on the concept.