### PR TITLE
Remove double spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ The [Commons Clause](https://commonsclause.com) is a License Condition drafted b
 
 The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
 
-Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you,  right to Sell the Software.
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you, right to Sell the Software.
 
-For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software.  Any license notice or attribution required by the License must also include this Commons Cause License Condition notice.
+For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software. Any license notice or attribution required by the License must also include this Commons Cause License Condition notice.
 
 Software: [name software]
 License: [i.e. Apache 2.0]


### PR DESCRIPTION
I assume those double spaces are small typos. They are not explicitly present in: https://commonsclause.com